### PR TITLE
chore: update package type to "module"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "summon-ts",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "summon-ts",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.3.16",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "summon-ts",
   "version": "0.2.3",
   "description": "TypeScript build of the Summon compiler (via wasm).",
+  "type": "module",
   "main": "dist/src/index.js",
   "scripts": {
     "build": "rm -rf dist srcWasm && tsx wasm/build.ts && tsc",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { getWasmLib, initWasmLib } from './wasmLib';
+import { getWasmLib, initWasmLib } from './wasmLib.js';
 
 export async function init() {
   await initWasmLib();

--- a/src/wasmLib.ts
+++ b/src/wasmLib.ts
@@ -1,4 +1,4 @@
-import * as bindgen from '../srcWasm/summon_ts_wasm';
+import * as bindgen from '../srcWasm/summon_ts_wasm.js';
 
 function base64ToUint8Array(base64: string) {
   var binaryString = atob(base64);
@@ -16,7 +16,7 @@ let lib: typeof bindgen | undefined = undefined;
 export function initWasmLib() {
   promise ??= (async () => {
     const { default: wasmBase64 } = await import(
-      '../srcWasm/summon_ts_wasm_base64',
+      '../srcWasm/summon_ts_wasm_base64.js',
     );
 
     bindgen.initSync(base64ToUint8Array(wasmBase64));

--- a/wasm/build.ts
+++ b/wasm/build.ts
@@ -1,5 +1,10 @@
 import { spawn } from 'child_process';
 import fs from 'fs/promises';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 process.chdir(__dirname);
 


### PR DESCRIPTION
This PR resolves compatibility issues with Node.js by setting the package type to module in `package.json`. This ensures the package works in both modern browsers and Node.js environments.

It has been tested on Node v20.10.0 and on browsers with Vite v6.0.5 + React v18.3.1.

A temporary package ([`summon-ts-pr-1`](https://www.npmjs.com/package/summon-ts-pr-1)) has been released to create a [Summon Node CLI](https://github.com/cedoor/mpc-cli/tree/main/packages/cli-summonc) to compile circuits and test this patch in prod (may be useful for JS devs who don't know/want to use https://github.com/voltrevo/summon). Try it by running `npx @mpc-cli/summonc main.ts`.

The following tips are not directly related to this PR.

> [!TIP]
> Consumers using CommonJS may need adjustments with the current configuration. This and similar packages should integrate [conditional exports](https://nodejs.org/api/packages.html#conditional-exports) and a more flexible configuration to support all envs seamlessly. Example -> [zk-kit imt package.json](https://github.com/privacy-scaling-explorations/zk-kit/blob/54f175d06af2fe556367675f68e241b56bc4293b/packages/imt/package.json#L5-L18).

> [!TIP]
> Tools like Rollup and similar build systems offer plugins that streamline the process of converting WASM to JS, making the workflow easier. Example -> https://github.com/rollup/plugins/tree/master/packages/wasm/#using-with-wasm-bindgen-and-wasm-pack (+ Rollup bundles all files into 1 unique file, reducing overhead of compatibility issues).