### PR TITLE
feat: support injecting file reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ async function main() {
 main().catch(console.error);
 ```
 
+When providing `files` to the API, you can also substitute a file reader `(filePath: string) => string`. Like this:
+
+```ts
+summon.compile(
+  '/full/path/to/main.ts',
+  (filePath) => fs.readFileSync(filePath),
+);
+```
+
 ## Development
 
 Build with `npm run build`. This will compile the wasm subproject and also

--- a/circuit/isLarger.ts
+++ b/circuit/isLarger.ts
@@ -1,0 +1,3 @@
+export default function isLarger(a: number, b: number): boolean {
+  return a > b;
+}

--- a/circuit/main.ts
+++ b/circuit/main.ts
@@ -1,0 +1,7 @@
+// This obviously doesn't need to be a separate file, but it's here to
+// demonstrate that you can split up your summon code like this.
+import isLarger from './isLarger.ts';
+
+export default function main(a: number, b: number) {
+  return isLarger(a, b) ? a : b;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "summon-ts",
-  "version": "0.2.3",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "summon-ts",
-      "version": "0.2.3",
+      "version": "0.2.5",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.3.16",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,53 +1,38 @@
-import { getWasmLib, initWasmLib } from './wasmLib.js';
-import {isNodeEnv} from './utils.js';
-
-let fs: any
+import {getWasmLib, initWasmLib} from './wasmLib.js';
 
 export async function init() {
   await initWasmLib();
-
-  if (isNodeEnv()) {
-      fs = await import('fs')
-  }
 }
 
 export function compile(
   path: string,
-  files?: Record<string, string>,
+  filesOrFileReader: Record<string, string> | ((path: string) => string),
 ): Circuit {
-  if (!files) {
-    if (!fs) {
-        throw new Error('Circuit object must be provided outside of Node.js')
-    }
-
+  if (typeof filesOrFileReader === 'function') {
     return getWasmLib().compile_impl_from_file(
       path,
       undefined,
-      (filePath: string) => fs.readFileSync(filePath, 'utf8')
+      filesOrFileReader
     );
   }
 
-  return getWasmLib().compile_impl_from_object(path, undefined, files);
+  return getWasmLib().compile_impl_from_object(path, undefined, filesOrFileReader);
 }
 
 export function compileBoolean(
   path: string,
   boolifyWidth: number,
-  files?: Record<string, string>,
+  filesOrFileReader: Record<string, string> | ((path: string) => string),
 ): Circuit {
-  if (!files) {
-    if (!fs) {
-        throw new Error('Circuit object must be provided outside of Node.js')
-    }
-
+  if (typeof filesOrFileReader === 'function') {
     return getWasmLib().compile_impl_from_file(
       path,
       boolifyWidth,
-      (filePath: string) => fs.readFileSync(filePath, 'utf8')
+      filesOrFileReader
     );
   }
 
-  return getWasmLib().compile_impl_from_object(path, boolifyWidth, files);
+  return getWasmLib().compile_impl_from_object(path, boolifyWidth, filesOrFileReader);
 }
 
 // TODO: Define this in shared lib

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,53 @@
 import { getWasmLib, initWasmLib } from './wasmLib.js';
+import {isNodeEnv} from './utils.js';
+
+let fs: any
 
 export async function init() {
   await initWasmLib();
+
+  if (isNodeEnv()) {
+      fs = await import('fs')
+  }
 }
 
 export function compile(
   path: string,
-  files: Record<string, string>,
+  files?: Record<string, string>,
 ): Circuit {
-  return getWasmLib().compile(path, files);
+  if (!files) {
+    if (!fs) {
+        throw new Error('Circuit object must be provided outside of Node.js')
+    }
+
+    return getWasmLib().compile_impl_from_file(
+      path,
+      undefined,
+      (filePath: string) => fs.readFileSync(filePath, 'utf8')
+    );
+  }
+
+  return getWasmLib().compile_impl_from_object(path, undefined, files);
 }
 
 export function compileBoolean(
   path: string,
   boolifyWidth: number,
-  files: Record<string, string>,
+  files?: Record<string, string>,
 ): Circuit {
-  return getWasmLib().compile_boolean(path, boolifyWidth, files);
+  if (!files) {
+    if (!fs) {
+        throw new Error('Circuit object must be provided outside of Node.js')
+    }
+
+    return getWasmLib().compile_impl_from_file(
+      path,
+      boolifyWidth,
+      (filePath: string) => fs.readFileSync(filePath, 'utf8')
+    );
+  }
+
+  return getWasmLib().compile_impl_from_object(path, boolifyWidth, files);
 }
 
 // TODO: Define this in shared lib

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,6 @@
+export function isNodeEnv() {
+ return typeof process !== 'undefined' &&
+   process.versions != null &&
+   process.versions.node != null;
+}
+

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,0 @@
-export function isNodeEnv() {
- return typeof process !== 'undefined' &&
-   process.versions != null &&
-   process.versions.node != null;
-}
-

--- a/tests/summon.test.ts
+++ b/tests/summon.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { readFileSync } from 'fs';
 
 import * as summon from '../src/index';
 import blockTrim from './helpers/blockTrim';
@@ -9,7 +10,7 @@ describe('summon', () => {
   });
 
   it('compiles a circuit from the file system', () => {
-    const circuit = summon.compile('./circuit/main.ts');
+    const circuit = summon.compile('./circuit/main.ts', (filePath) => readFileSync(filePath, 'utf8'));
 
     const expectedCircuit = summon.compile('/src/main.ts', {
       '/src/main.ts': `

--- a/tests/summon.test.ts
+++ b/tests/summon.test.ts
@@ -8,6 +8,27 @@ describe('summon', () => {
     await summon.init();
   });
 
+  it('compiles a circuit from the file system', () => {
+    const circuit = summon.compile('./circuit/main.ts');
+
+    const expectedCircuit = summon.compile('/src/main.ts', {
+      '/src/main.ts': `
+        import isLarger from './isLarger.ts';
+
+        export default function main(a: number, b: number) {
+          return isLarger(a, b) ? a : b;
+        }
+      `,
+      '/src/isLarger.ts': `
+        export default function isLarger(a: number, b: number): boolean {
+          return a > b;
+        }
+      `
+    });
+
+    expect(circuit).to.be.deep.equal(expectedCircuit)
+  })
+
   it('compiles addition', () => {
     const circuit = summon.compile('/src/main.ts', {
       '/src/main.ts': `

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -105,5 +105,6 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "exclude": ["circuit"]
 }


### PR DESCRIPTION
## What is this PR doing?

This PR adds wasm bindings to pass a file reader instead of an object when compiling Summon circuits.

It only works on Node and it doesn't introduce any breaking change. The `compile` and `compileBoolean` functions take the same parameters but `files` is not required now. If it is not defined, a file reader will be used to find the circuit code.

The library has been tested with Vite, Next.js, and Node. Next.js requires additional configuration in the `next.config.ts` file:

```ts
const nextConfig: NextConfig = {
    webpack: (config) => {
        config.resolve.fallback = { fs: false }

        return config
    }
};
```

similarly to [`emp-wasm`](https://github.com/voltrevo/emp-wasm).

## How can these changes be manually tested?

The library can be tested locally in other projects by running `npm i <lib-path> --save`.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat
