### PR TITLE
chore: update summon & boolify dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "summon-ts",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "TypeScript build of the Summon compiler (via wasm).",
   "type": "module",
   "main": "dist/src/index.js",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
 [[package]]
 name = "boolify"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/boolify?rev=8766836#8766836d93cdf427fae0b0b612b94443c20d5b28"
+source = "git+https://github.com/voltrevo/boolify?rev=f68ee3a#f68ee3a66e8c762dabda5be4bbe1f328d2b8fdd8"
 dependencies = [
  "bristol-circuit",
  "serde",
@@ -176,7 +176,7 @@ dependencies = [
 [[package]]
 name = "bristol-circuit"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/bristol-circuit?rev=2394ccc#2394ccc53e69de5f59b62da5386096050e307649"
+source = "git+https://github.com/voltrevo/bristol-circuit?rev=288847c#288847cdf8391627eeaaf2adea8971f944ea055f"
 dependencies = [
  "serde",
  "serde_json",
@@ -1494,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "summon_compiler"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/summon?rev=2f0f317#2f0f317142199c3f8564a0dabf16e7739c46b585"
+source = "git+https://github.com/voltrevo/summon?rev=f48e781#f48e7810fdaec20e641a1b00c106eee03ce70282"
 dependencies = [
  "bristol-circuit",
  "num-bigint",

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -8,8 +8,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wasm-bindgen = "0.2.92"
-summon_compiler = { git = "https://github.com/voltrevo/summon", rev = "2f0f317" }
-boolify = { git = "https://github.com/voltrevo/boolify", rev = "8766836" }
+summon_compiler = { git = "https://github.com/voltrevo/summon", rev = "f48e781" }
+boolify = { git = "https://github.com/voltrevo/boolify", rev = "f68ee3a" }
 serde-wasm-bindgen = { version = "0.6.5", serialize_maps_as_objects = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## What is this PR doing?

This PR updates the following Rust dependencies: `summon`,  `boolify`. And it bumps a new version.

## How can these changes be manually tested?

Run `npm run build` and `npm test`.

## Does this PR resolve or contribute to any issues?

No.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
