### PR TITLE
fix: return diagnostic and circuit after compiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ async function main() {
 
   // for boolean circuits: summon.compileBoolean('/src/main.ts', 8, { ... })
   // (replace 8 with your desired uint precision)
-  const circuit = summon.compile('/src/main.ts', {
+  const { circuit } = summon.compile('/src/main.ts', {
     // In a real project you should be able to include these as regular files,
     // but how those files find their way into this format depends on your build
     // tool.

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export async function init() {
 export function compile(
   path: string,
   filesOrFileReader: Record<string, string> | ((path: string) => string),
-): Circuit {
+): CompileOk {
   if (typeof filesOrFileReader === 'function') {
     return getWasmLib().compile_impl_from_file(
       path,
@@ -27,7 +27,7 @@ export function compileBoolean(
   path: string,
   boolifyWidth: number,
   filesOrFileReader: Record<string, string> | ((path: string) => string),
-): Circuit {
+): CompileOk {
   if (typeof filesOrFileReader === 'function') {
     return getWasmLib().compile_impl_from_file(
       path,
@@ -43,7 +43,21 @@ export function compileBoolean(
   );
 }
 
-// TODO: Define this in shared lib
+// TODO: Define these types in shared lib.
+
+type Diagnostics = Record<
+  string,
+  {
+    level: string;
+    message: string;
+    span: {
+      start: number;
+      end: number;
+      ctxt: number;
+    };
+  }[]
+>;
+
 type Circuit = {
   bristol: string;
   info: {
@@ -51,4 +65,9 @@ type Circuit = {
     constants: Record<string, { value: string; wire_index: number }>;
     output_name_to_wire_index: Record<string, number>;
   };
+};
+
+type CompileOk = {
+  circuit: Circuit;
+  diagnostics: Diagnostics;
 };


### PR DESCRIPTION
## What is this PR doing?

This PR refines the object returned after compiling circuits in JS, ensuring consistency with [summon](https://github.com/voltrevo/summon) and enhancing diagnostic capabilities. Specifically, it introduces:
* A new `diagnostics` field, providing valuable debug information for developers and for tools like [cli-summon](https://github.com/cedoor/mpc-cli/tree/main/packages/cli-summon).
* A `CompileOk` type, mirroring the Rust implementation but including the Bristol circuit representation.

This update breaks backward compatibility with previous versions. So the decision on whether to enforce strict errors or compile while returning errors within diagnostics is left to @voltrevo. Given the project's current stage, I believe this is a reasonable time to introduce such changes if they improve the APIs.

## How can these changes be manually tested?

Run `npm test`.

## Does this PR resolve or contribute to any issues?

No.

## Checklist
- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
