### PR TITLE
Update deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "summon-ts",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "summon-ts",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.3.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "summon-ts",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "TypeScript build of the Summon compiler (via wasm).",
   "type": "module",
   "main": "dist/src/index.js",

--- a/tests/summon.test.ts
+++ b/tests/summon.test.ts
@@ -115,14 +115,6 @@ describe('summon', () => {
     });
   });
 
-  // FIXME: on linux / gh actions:
-  //   "input_name_to_wire_index": {
-  // -      "a": 8
-  // -      "b": 0
-  // +      "a": 0
-  // +      "b": 8
-  //   }
-  // https://github.com/voltrevo/summon-ts/actions/runs/12627100358/job/35181187804?pr=2#step:10:35
   it('compiles xor', () => {
     const { circuit } = summon.compileBoolean('/src/main.ts', 8, {
       '/src/main.ts': `
@@ -138,14 +130,14 @@ describe('summon', () => {
         2 8 8
         1 8
 
-        2 1 7 15 23 XOR
-        2 1 0 0 16 XOR
-        1 1 16 22 COPY
-        1 1 16 21 COPY
-        1 1 16 20 COPY
-        1 1 16 19 COPY
-        1 1 16 18 COPY
-        1 1 16 17 COPY
+        2 1 0 8 16 XOR
+        2 1 0 0 17 XOR
+        1 1 17 18 COPY
+        1 1 17 19 COPY
+        1 1 17 20 COPY
+        1 1 17 21 COPY
+        1 1 17 22 COPY
+        1 1 17 23 COPY
       `),
       info: {
         input_name_to_wire_index: {

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -166,7 +166,7 @@ dependencies = [
 [[package]]
 name = "boolify"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/boolify?rev=f68ee3a#f68ee3a66e8c762dabda5be4bbe1f328d2b8fdd8"
+source = "git+https://github.com/voltrevo/boolify?rev=cec0efa#cec0efa7ad938da96078e9e2a65a741b1417918a"
 dependencies = [
  "bristol-circuit",
  "serde",
@@ -1418,7 +1418,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/ValueScript?rev=ae82029#ae82029f0d5b147c057b02acd7076d38446e88aa"
+source = "git+https://github.com/voltrevo/summon?rev=dd3833d#dd3833da09ddb8acd32d9d0441d8e486576a4680"
 dependencies = [
  "bincode",
  "num-bigint",
@@ -1492,18 +1492,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "summon_common"
+version = "0.1.0"
+source = "git+https://github.com/voltrevo/summon?rev=dd3833d#dd3833da09ddb8acd32d9d0441d8e486576a4680"
+dependencies = [
+ "strum",
+ "strum_macros",
+]
+
+[[package]]
 name = "summon_compiler"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/summon?rev=b6d5744#b6d5744e6b35639a91044607828537f44196fadf"
+source = "git+https://github.com/voltrevo/summon?rev=dd3833d#dd3833da09ddb8acd32d9d0441d8e486576a4680"
 dependencies = [
  "bristol-circuit",
  "num-bigint",
  "num-traits",
+ "queues",
  "serde",
  "serde_json",
- "valuescript_common",
- "valuescript_compiler",
- "valuescript_vm",
+ "summon_common",
+ "summon_vm",
+ "swc",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -1520,6 +1535,20 @@ dependencies = [
  "summon_compiler",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "summon_vm"
+version = "0.1.0"
+source = "git+https://github.com/voltrevo/summon?rev=dd3833d#dd3833da09ddb8acd32d9d0441d8e486576a4680"
+dependencies = [
+ "bristol-circuit",
+ "num-bigint",
+ "num-derive",
+ "num-traits",
+ "serde_json",
+ "storage",
+ "summon_common",
 ]
 
 [[package]]
@@ -2375,48 +2404,6 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
-]
-
-[[package]]
-name = "valuescript_common"
-version = "0.1.0"
-source = "git+https://github.com/voltrevo/ValueScript?rev=ae82029#ae82029f0d5b147c057b02acd7076d38446e88aa"
-dependencies = [
- "strum",
- "strum_macros",
-]
-
-[[package]]
-name = "valuescript_compiler"
-version = "0.1.0"
-source = "git+https://github.com/voltrevo/ValueScript?rev=ae82029#ae82029f0d5b147c057b02acd7076d38446e88aa"
-dependencies = [
- "num-bigint",
- "num-traits",
- "queues",
- "serde",
- "serde_json",
- "swc",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "tiny-keccak",
- "valuescript_common",
- "valuescript_vm",
-]
-
-[[package]]
-name = "valuescript_vm"
-version = "0.1.0"
-source = "git+https://github.com/voltrevo/ValueScript?rev=ae82029#ae82029f0d5b147c057b02acd7076d38446e88aa"
-dependencies = [
- "num-bigint",
- "num-derive",
- "num-traits",
- "serde_json",
- "storage",
- "valuescript_common",
 ]
 
 [[package]]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -8,8 +8,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wasm-bindgen = "0.2.92"
-summon_compiler = { git = "https://github.com/voltrevo/summon", rev = "b6d5744" }
-boolify = { git = "https://github.com/voltrevo/boolify", rev = "f68ee3a" }
+summon_compiler = { git = "https://github.com/voltrevo/summon", rev = "dd3833d" }
+boolify = { git = "https://github.com/voltrevo/boolify", rev = "cec0efa" }
 serde-wasm-bindgen = { version = "0.6.5", serialize_maps_as_objects = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## What is this PR doing?

Updates dependencies for summon and boolify.

This includes the little endian update in boolify, so the PR includes an update to the test to reflect the new bit order.

Also includes fixes for stack overflows.

## How can these changes be manually tested?

Compile this circuit:

```ts
const ITER = 100_000;

export default function main(x: number) {
  let fa = x;
  let fb = 0;

  for (let i = 0; i < ITER; i++) {
    [fa, fb] = [fb, (fa + fb)];
  }

  return fb;
}
```

## Does this PR resolve or contribute to any issues?

Contributes to https://www.notion.so/pse-team/Fix-summon-stack-overflow-196d57e8dd7e80bca257ddcd16ab5b18?pvs=4

## Checklist

- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines

- If your PR is not ready, mark it as a draft
