### PR TITLE
Fix types import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "summon-ts",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "summon-ts",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.3.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "summon-ts",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "TypeScript build of the Summon compiler (via wasm).",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/compileError.ts
+++ b/src/compileError.ts
@@ -1,4 +1,9 @@
-import { Circuit, CompileResult, DiagnosticLevel, Diagnostics } from './types';
+import {
+  Circuit,
+  CompileResult,
+  DiagnosticLevel,
+  Diagnostics,
+} from './types.js';
 
 /**
  * Custom error class for handling Summon compilation errors.


### PR DESCRIPTION
## What is this PR doing?

Importing without the file extension is not technically correct, causing things to break in some circumstances. One example occurs when running deno in a node project, but not when running deno in a deno project that uses npm/nodejs modules.

## How can these changes be manually tested?

[mpcf-test.zip](https://github.com/user-attachments/files/19676274/mpcf-test.zip)
`npm install`
`deno run --unstable-sloppy-imports main.ts`

This should reproduce the following error:

```
error: [ERR_MODULE_NOT_FOUND] Cannot find module 'file:///Users/dev/workspaces/mpcf-test/node_modules/summon-ts/dist/src/types' imported from 'file:///Users/dev/workspaces/mpcf-test/node_modules/summon-ts/dist/src/compileError.js'
Did you mean to import with the ".js" extension?
```

You can then resolve it by modifying compileError.js directly in node_modules to import './types.js' instead of './types', then run `deno run --unstable-sloppy-imports main.ts` again:

```
[ { main: 10 }, { main: 10 } ]
```

To check the change in this PR is correct, run `npm run build` (in this project+branch) and check that compileError.js (in `dist`) imports './types.js'.

## Does this PR resolve or contribute to any issues?

Contributes to https://www.notion.so/pse-team/Support-Deno-15ed57e8dd7e801497b6ee1a7813df12?pvs=4

## Checklist

- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines

- If your PR is not ready, mark it as a draft
