### PR TITLE
Upgrade summon and use io api

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-  "editor.rulers": [80]
+  "editor.rulers": [80],
+  "editor.tabSize": 2,
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ async function main() {
       // In a real project you should be able to include these as regular files,
       // but how those files find their way into this format depends on your build
       // tool.
-      // Example: https://github.com/voltrevo/mpc-hello/blob/c1c8092/src/getCircuitFiles.ts
+      // Example: https://github.com/privacy-scaling-explorations/mpc-hello/blob/c1c8092/src/getCircuitFiles.ts
 
       "/src/main.ts": `
         export default (io: Summon.IO) {
@@ -53,7 +53,7 @@ async function main() {
   // { './circuit/main.ts': [] }
 
   // See mpc-framework for doing MPC with your circuits.
-  // https://github.com/voltrevo/mpc-framework
+  // https://github.com/privacy-scaling-explorations/mpc-framework
 }
 
 // When summon.compile throws, the error message will be the first error

--- a/circuit/main.ts
+++ b/circuit/main.ts
@@ -1,7 +1,12 @@
+import './summon.d.ts';
+
 // This obviously doesn't need to be a separate file, but it's here to
 // demonstrate that you can split up your summon code like this.
 import isLarger from './isLarger.ts';
 
-export default function main(a: number, b: number) {
-  return isLarger(a, b) ? a : b;
-}
+export default (io: Summon.IO) => {
+  const a = io.input('alice', 'a', summon.number());
+  const b = io.input('bob', 'b', summon.number());
+
+  io.outputPublic('res', isLarger(a, b));
+};

--- a/circuit/summon.d.ts
+++ b/circuit/summon.d.ts
@@ -1,0 +1,58 @@
+declare const summon: {
+  /**
+   * Tests whether the provided `value` is a signal.
+   *
+   * Signals are used to generate circuits during partial evaluation by representing computations
+   * over unknown values.
+   *
+   *     const x = summon.inputPublic('x', summon.number());
+   *     const y = 17;
+   *
+   *     summon.isSignal(x); // true
+   *     summon.isSignal(y); // false
+   *     summon.isSignal(x + y); // true
+   */
+  isSignal(value: unknown): boolean;
+
+  /** Produces a runtime value that models the type `number`. */
+  number(): Summon.Type<number>;
+
+  /** Produces a runtime value that models the type `boolean`. */
+  bool(): Summon.Type<boolean>;
+};
+
+declare namespace Summon {
+  export type IO = {
+    /** Accept an input from a specific party. */
+    input<T>(from: string, name: string, type: Type<T>): T;
+
+    /** Accept a compile-time input (all parties must provide the same value). */
+    inputPublic<T>(name: string, type: Type<T>): T;
+
+    /** Provide an output visible only to a specific party or parties. */
+    output<T>(to: string | string[], name: string, value: T): void;
+
+    /** Provide an output visible to all parties. */
+    outputPublic<T>(name: string, value: T): void;
+
+    /**
+     * Explicitly add an MPC party.
+     *
+     * Usually parties are inferred from inputs and outputs, but you can also have parties with no
+     * inputs and only receive public outputs. Use this method to declare them so they will be
+     * included in mpcSettings.
+     */
+    addParty(name: string): void;
+  };
+
+  export type Type<T> = {
+    about: 'summon runtime type';
+    json: unknown;
+
+    // This is just here to help keep TypeScript aware of T. This field is never supposed to
+    // actually be present.
+    _typeCheck?: (x: T) => T;
+  };
+
+  export type TypeOf<T> = T extends Type<infer U> ? U : never;
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "Andrew Morris",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/voltrevo/summon-ts.git"
+    "url": "git+https://github.com/privacy-scaling-explorations/summon-ts.git"
   },
   "license": "MIT",
   "devDependencies": {

--- a/src/helpers/never.ts
+++ b/src/helpers/never.ts
@@ -1,0 +1,3 @@
+export default function never(x: never): never {
+  throw new Error(`Unexpected object: ${x}`);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import CompileError, { getErrorFromDiagnostic } from './compileError.js';
+import never from './helpers/never.js';
 import { CompileResult } from './types.js';
 import { getWasmLib, initWasmLib } from './wasmLib.js';
 
@@ -12,27 +13,55 @@ export async function init() {
 }
 
 /**
- * Handles the compilation process based on the provided input type.
+ * Compiles the given circuit from a file path, with optional boolean transformation.
  *
- * @param {string} path - The path to the main circuit file.
- * @param {number | undefined} boolifyWidth - Optional parameter for boolean transformation.
- * @param {Record<string, string> | ((path: string) => string)} filesOrFileReader -
- *        Either an object mapping file names to their contents or a function to fetch file contents dynamically.
+ * Files must be provided as a `files` object or a `readFile` function.
+ *
+ * @param {Object} opt - Options for compilation.
+ * @param {string} opt.path - The path to the main circuit file.
+ * @param {number | undefined} [opt.boolifyWidth] - Optional parameter for boolean transformation.
+ * @param {Record<string, unknown> | undefined} [opt.publicInputs] - Optional: Public inputs for the circuit.
+ * @param {((path: string) => string) | undefined} [opt.readFile] - Optional: A function to read file contents.
+ * @param {Record<string, string> | undefined} [opt.files] - Optional: An object mapping file names to their contents.
  * @returns {CompileResult} - The result of the compilation process.
  * @throws {CompileError} - If the compilation encounters an error.
  */
-function compileCircuit(
-  path: string,
-  boolifyWidth: number | undefined,
-  filesOrFileReader: Record<string, string> | ((path: string) => string),
+export function compile(
+  opt: {
+    path: string;
+    boolifyWidth?: number;
+    publicInputs?: Record<string, unknown>;
+  } & FilesOrReadFile,
 ): CompileResult {
+  const { path, boolifyWidth, publicInputs = {} } = opt;
+
+  const readFile = (() => {
+    if ('readFile' in opt) {
+      return opt.readFile;
+    }
+
+    if ('files' in opt) {
+      return (path: string) => {
+        if (path in opt.files) {
+          return opt.files[path];
+        }
+
+        throw new Error(`File not found: ${path}`);
+      };
+    }
+
+    never(opt);
+  })();
+
   const wasmLib = getWasmLib();
 
   // Determine whether to use a function-based or object-based compilation method.
-  const compileResult =
-    typeof filesOrFileReader === 'function'
-      ? wasmLib.compile_impl_from_file(path, boolifyWidth, filesOrFileReader)
-      : wasmLib.compile_impl_from_object(path, boolifyWidth, filesOrFileReader);
+  const compileResult = wasmLib.compile(
+    path,
+    boolifyWidth,
+    JSON.stringify(publicInputs),
+    readFile,
+  );
 
   // Extract error message from diagnostics, if any.
   const errorMessage = getErrorFromDiagnostic(compileResult.diagnostics);
@@ -44,36 +73,6 @@ function compileCircuit(
   return compileResult;
 }
 
-/**
- * Compiles the given circuit from either an object containing files or a file reader function.
- *
- * @param {string} path - The path to the main circuit file.
- * @param {Record<string, string> | ((path: string) => string)} filesOrFileReader -
- *        Either an object mapping file names to their contents or a function to fetch file contents dynamically.
- * @returns {CompileResult} - The result of the compilation process.
- * @throws {CompileError} - If the compilation encounters an error.
- */
-export function compile(
-  path: string,
-  filesOrFileReader: Record<string, string> | ((path: string) => string),
-): CompileResult {
-  return compileCircuit(path, undefined, filesOrFileReader);
-}
-
-/**
- * Compiles the given circuit with boolean transformation (boolification).
- *
- * @param {string} path - The path to the main circuit file.
- * @param {number} boolifyWidth - The width parameter for boolean transformation.
- * @param {Record<string, string> | ((path: string) => string)} filesOrFileReader -
- *        Either an object mapping file names to their contents or a function to fetch file contents dynamically.
- * @returns {CompileResult} - The result of the compilation process.
- * @throws {CompileError} - If the compilation encounters an error.
- */
-export function compileBoolean(
-  path: string,
-  boolifyWidth: number,
-  filesOrFileReader: Record<string, string> | ((path: string) => string),
-): CompileResult {
-  return compileCircuit(path, boolifyWidth, filesOrFileReader);
-}
+type FilesOrReadFile =
+  | { files: Record<string, string> }
+  | { readFile: (path: string) => string };

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,13 +22,27 @@ export type Diagnostics = Record<string, Diagnostic[]>;
 export type Circuit = {
   bristol: string;
   info: {
-    input_name_to_wire_index: Record<string, number>;
-    constants: Record<string, { value: string; wire_index: number }>;
-    output_name_to_wire_index: Record<string, number>;
+    constants: (CircuitIOInfo & { value: unknown })[];
+    inputs: CircuitIOInfo[];
+    outputs: CircuitIOInfo[];
   };
+  mpcSettings: MpcParticipantSettings[];
+};
+
+export type CircuitIOInfo = {
+  name: string;
+  type: unknown;
+  address: number;
+  width: number;
 };
 
 export type CompileResult = {
   circuit: Circuit;
   diagnostics: Diagnostics;
+};
+
+type MpcParticipantSettings = {
+  name: string;
+  inputs: string[];
+  outputs: string[];
 };

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 [[package]]
 name = "boolify"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/boolify?rev=380a815#380a81588ac8e262f563e0158b65e4db03da1554"
+source = "git+https://github.com/privacy-scaling-explorations/boolify?rev=380a815#380a81588ac8e262f563e0158b65e4db03da1554"
 dependencies = [
  "bristol-circuit",
  "serde",
@@ -1370,7 +1370,7 @@ dependencies = [
 [[package]]
 name = "summon_common"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/summon?rev=3e14d44#3e14d44bacac0acedf92cacd2255a9bac2a9aded"
+source = "git+https://github.com/privacy-scaling-explorations/summon?rev=3e14d44#3e14d44bacac0acedf92cacd2255a9bac2a9aded"
 dependencies = [
  "serde_json",
  "strum",
@@ -1380,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "summon_compiler"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/summon?rev=3e14d44#3e14d44bacac0acedf92cacd2255a9bac2a9aded"
+source = "git+https://github.com/privacy-scaling-explorations/summon?rev=3e14d44#3e14d44bacac0acedf92cacd2255a9bac2a9aded"
 dependencies = [
  "bristol-circuit",
  "num-bigint",
@@ -1417,7 +1417,7 @@ dependencies = [
 [[package]]
 name = "summon_vm"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/summon?rev=3e14d44#3e14d44bacac0acedf92cacd2255a9bac2a9aded"
+source = "git+https://github.com/privacy-scaling-explorations/summon?rev=3e14d44#3e14d44bacac0acedf92cacd2255a9bac2a9aded"
 dependencies = [
  "bristol-circuit",
  "num-bigint",

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 [[package]]
 name = "boolify"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/boolify?rev=09a5636#09a5636fffef8025eaf4f847dacb16e886853d6a"
+source = "git+https://github.com/voltrevo/boolify?rev=380a815#380a81588ac8e262f563e0158b65e4db03da1554"
 dependencies = [
  "bristol-circuit",
  "serde",
@@ -167,7 +167,7 @@ dependencies = [
 [[package]]
 name = "bristol-circuit"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/bristol-circuit?rev=288847c#288847cdf8391627eeaaf2adea8971f944ea055f"
+source = "git+https://github.com/voltrevo/bristol-circuit?rev=10ee9c7#10ee9c7c07d3cfdd7163b4c8ebf529a72c1006bb"
 dependencies = [
  "serde",
  "serde_json",
@@ -1370,8 +1370,9 @@ dependencies = [
 [[package]]
 name = "summon_common"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/summon?rev=a1dfc1c#a1dfc1cb38010a88043172a72bcbeadc8b494027"
+source = "git+https://github.com/voltrevo/summon?rev=3e14d44#3e14d44bacac0acedf92cacd2255a9bac2a9aded"
 dependencies = [
+ "serde_json",
  "strum",
  "strum_macros",
 ]
@@ -1379,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "summon_compiler"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/summon?rev=a1dfc1c#a1dfc1cb38010a88043172a72bcbeadc8b494027"
+source = "git+https://github.com/voltrevo/summon?rev=3e14d44#3e14d44bacac0acedf92cacd2255a9bac2a9aded"
 dependencies = [
  "bristol-circuit",
  "num-bigint",
@@ -1416,12 +1417,13 @@ dependencies = [
 [[package]]
 name = "summon_vm"
 version = "0.1.0"
-source = "git+https://github.com/voltrevo/summon?rev=a1dfc1c#a1dfc1cb38010a88043172a72bcbeadc8b494027"
+source = "git+https://github.com/voltrevo/summon?rev=3e14d44#3e14d44bacac0acedf92cacd2255a9bac2a9aded"
 dependencies = [
  "bristol-circuit",
  "num-bigint",
  "num-derive",
  "num-traits",
+ "serde",
  "serde_json",
  "summon_common",
 ]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -8,8 +8,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wasm-bindgen = "0.2.92"
-summon_compiler = { git = "https://github.com/voltrevo/summon", rev = "a1dfc1c" }
-boolify = { git = "https://github.com/voltrevo/boolify", rev = "09a5636" }
+summon_compiler = { git = "https://github.com/voltrevo/summon", rev = "3e14d44" }
+boolify = { git = "https://github.com/voltrevo/boolify", rev = "380a815" }
 serde-wasm-bindgen = { version = "0.6.5", serialize_maps_as_objects = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -8,8 +8,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wasm-bindgen = "0.2.92"
-summon_compiler = { git = "https://github.com/voltrevo/summon", rev = "3e14d44" }
-boolify = { git = "https://github.com/voltrevo/boolify", rev = "380a815" }
+summon_compiler = { git = "https://github.com/privacy-scaling-explorations/summon", rev = "3e14d44" }
+boolify = { git = "https://github.com/privacy-scaling-explorations/boolify", rev = "380a815" }
 serde-wasm-bindgen = { version = "0.6.5", serialize_maps_as_objects = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## What is this PR doing?

Upgrades to the new summon and updates to use the new io api.

Also:
- Consolidated summon-ts api to just `compile` with named arguments
  - including optional `boolifyWidth` argument rather than separate `compile` and `compileBoolean` apis
- Refactor lib.rs

## How can these changes be manually tested?

`npm run build`
`npm test`

## Does this PR resolve or contribute to any issues?

Contributes to https://www.notion.so/pse-team/Rich-IO-15ed57e8dd7e80058612d5519bff625b?pvs=4

## Checklist

- [x] I have manually tested these changes
- [x] Post a link to the PR in the group chat

## Guidelines

- If your PR is not ready, mark it as a draft
